### PR TITLE
fix ModeSMBData issue

### DIFF
--- a/src/data_item.rs
+++ b/src/data_item.rs
@@ -276,10 +276,6 @@ pub struct ModeSMBData {
     pub count: u8,
     #[deku(count = "count")]
     pub mb_data: Vec<MBData>,
-    #[deku(bits = "4")]
-    pub bds1: u8,
-    #[deku(bits = "4")]
-    pub bds2: u8,
 }
 
 impl ModeSMBData {
@@ -290,6 +286,10 @@ impl ModeSMBData {
 pub struct MBData {
     #[deku(count = "7")]
     pub data: Vec<u8>,
+    #[deku(bits = "4")]
+    pub bds1: u8,
+    #[deku(bits = "4")]
+    pub bds2: u8,
 }
 
 /// An integer value representing a unique reference to a track

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -74,10 +74,12 @@ fn it_works() {
         assert_eq!(mode_smb_data.count, 1);
         assert_eq_hex!(
             mode_smb_data.mb_data,
-            vec![MBData { data: [0xc0, 0x78, 0x00, 0x31, 0xbc, 0x00, 0x00].to_vec() }]
+            vec![MBData {
+                data: [0xc0, 0x78, 0x00, 0x31, 0xbc, 0x00, 0x00].to_vec(),
+                bds1: 4,
+                bds2: 0
+            }]
         );
-        // TODO assert BDS1
-        // TODO assert BDS2
 
         let track_number = message.track_number.as_ref().unwrap();
         assert_eq!(track_number.number, 3563);
@@ -212,10 +214,12 @@ fn third_packet() {
         assert_eq!(mode_smb_data.count, 1);
         assert_eq!(
             mode_smb_data.mb_data,
-            vec![MBData { data: [0xc6, 0x56, 0x32, 0xb0, 0xa8, 0x00, 0x00].to_vec() }]
+            vec![MBData {
+                data: [0xc6, 0x56, 0x32, 0xb0, 0xa8, 0x00, 0x00].to_vec(),
+                bds1: 4,
+                bds2: 0
+            }]
         );
-        assert_eq!(mode_smb_data.bds1, 4);
-        assert_eq!(mode_smb_data.bds2, 0);
 
         let track_number = message.track_number.as_ref().unwrap();
         assert_eq!(track_number.number, 482);


### PR DESCRIPTION
ModeSMBData previously placed the `bds1` and `bds2` nibbles as a single shared byte **after** the entire `mb_data` vector. Instead, the BDS address should be embedded inside each repeated record. This is defined in ASTERIX CAT048 Item I048/250